### PR TITLE
Readme and Definition changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ and publish messages in XML format using an [Event Handler](https://orkes.io/con
 [Event Task](https://orkes.io/content/reference-docs/system-tasks/event) respectively.
 
 The input and output of Workflows and Tasks in Orkes Conductor is always a JSON. However, if a message
-is received that's not in JSON format, that message will be available in the special key `__payload`. Similarly,
-to publish a raw string (XML or text other format) you could use `__payload` as well in the input of the
-Event task.
+is received that's not in JSON format, that message will be available as a string in the Workflow's input. 
+To publish a string (XML or any other text format) you can use the special key `__payload` in the input of the Event task.
 
 ## Consuming
 
@@ -23,13 +22,10 @@ If the following XML is sent to a queue and is read by an event handler:
 </user>
 ```
 
-The workflow input might look like this, with `__payload` set to the raw XML string:
+The workflow input might look like this. As you can see `['conductor.event.eventPayload'].message` is set to the XML string:
 ```json
 {
   "conductor.event.messageId": "BE1C55D1-F456-4279-945E-522DF9BABAA5",
-  "payload": {
-    "__payload": "<user>\r\n    <name>John Doe</name>\r\n    <age>20</age>\r\n    <email>john_doe@test.com</email>\r\n    <created>2024-06-03 19:22:00</created>\r\n</user>\r\n"
-  },
   "conductor.event.name": "amqp:amqptest:new-user-queue",
   "conductor.event.eventPayload": {
     "_amqpMessageId": "BE1C55D1-F456-4279-945E-522DF9BABAA5",
@@ -44,12 +40,23 @@ The workflow input might look like this, with `__payload` set to the raw XML str
     "event": "amqp:amqptest:new-user-queue"
   }
 }
+```
 
+That message can be used like in the workflow definition as an input to a Task, e.g.:
+
+```json
+{
+  "name": "approval_task",
+  "taskReferenceName": "approval_ref",
+  "inputParameters": {
+    "data": "${workflow.input['conductor.event.eventPayload'].message}"
+  },
+  ...
+}
 ```
 
 ## Publishing
-To send an XML message to a queue you can use an Event task with the special key `__payload` just
-like in the [workflow definition](docs/definitions/workflow.json) used in the demo.
+To send an XML message to a queue you can use an Event task with the special key `__payload` just like in the [workflow definition](docs/definitions/workflow.json) used in the demo.
 
 ```json
  {
@@ -80,3 +87,10 @@ In this sequence diagram you can visualize the data flow which starts when an XM
 queue and ends when an Event Task is used to publish another XML message to a different queue.
 
 ![](docs/xml_support_seq_diagram.png)
+
+
+### Notes
+- This is available since Orkes Conductor `3.3.54`.
+- In the demo `"data": "${workflow.input.payload.__payload}"` is used instead of `"data": "${workflow.input['conductor.event.eventPayload'].message}"`. 
+That was only available during initial development of this feature (custom payload support) and ended up being deprecated to avoid increasing the size 
+of the task payload unnecessarily.

--- a/docs/definitions/event-handler.json
+++ b/docs/definitions/event-handler.json
@@ -7,11 +7,8 @@
       "action": "start_workflow",
       "start_workflow": {
         "name": "user_onboarding_journey",
-        "version": 1,
+        "version": 2,
         "correlationId": "",
-        "input": {
-          "payload": "${$}"
-        },
         "taskToDomain": {},
         "priority": 0,
         "idempotencyKey": ""

--- a/docs/definitions/workflow.json
+++ b/docs/definitions/workflow.json
@@ -1,7 +1,7 @@
 {
   "name": "user_onboarding_journey",
-  "description": "When a new user subscribes to the Duff Experience this onboarding workflow is triggered",
-  "version": 1,
+  "description": "When a new user subscribes to the Duff Experience we trigger the onboarding flow",
+  "version": 2,
   "tasks": [
     {
       "name": "wait_0",
@@ -23,7 +23,7 @@
       "name": "approval_task",
       "taskReferenceName": "approval_ref",
       "inputParameters": {
-        "data": "${workflow.input.payload.__payload}"
+        "data": "${workflow.input['conductor.event.eventPayload'].message}"
       },
       "type": "SIMPLE",
       "decisionCases": {},


### PR DESCRIPTION
Updated documentation to match latest changes around this feature (custom payload support).

Documentation now uses `${workflow.input['conductor.event.eventPayload'].message}` instead of `${workflow.input.payload.__payload}`